### PR TITLE
Connect file.controller and flamegraphController

### DIFF
--- a/src/controllers/file.controller.ts
+++ b/src/controllers/file.controller.ts
@@ -6,9 +6,16 @@ import path from 'path';
 export default class FileController {
   public uploadDir = '../../database/uploads';
 
+  public captureDir = '../../database/captures';
+
+  public svgDir = '../../database/SVGs';
+
   addData = (req: Request, res: Response, next: NextFunction) => {
     // Get next ID
+    res.locals.id = 12345;
     const fileId = Number(res.locals.id);
+    // console.log('LOOK OVER HERE!', fileId);
+    // const fileId = 123;
 
     const processTempFile = (formName: string, file: formidable.File) => {
       // console.log(
@@ -25,7 +32,7 @@ export default class FileController {
       );
       const destinationPath = path.resolve(
         __dirname,
-        this.uploadDir,
+        this.captureDir,
         `${fileId}.perf`,
       );
 
@@ -48,5 +55,26 @@ export default class FileController {
     });
 
     uploads.parse(req);
+  };
+
+  deliverSVG = (req: Request, res: Response, next: NextFunction) => {
+    const fileId = Number(res.locals.id);
+    const fileName = path.resolve(
+      __dirname,
+      this.svgDir,
+      `${fileId}.svg`,
+    );
+    try {
+      res.sendFile(fileName, (err) => {
+        if (err) {
+          next(err);
+        } else {
+          console.log('Sent:', fileName);
+        }
+      });
+      return next();
+    } catch (err) {
+      return next(err);
+    }
   };
 }

--- a/src/routes/api.router.ts
+++ b/src/routes/api.router.ts
@@ -3,6 +3,7 @@ import {
   NextFunction, Router, Request, Response,
 } from 'express';
 import flamegraph from '../controllers/flamegraphController';
+import { fileController } from '../controllers/controllers.module';
 
 const apiRouter = Router();
 
@@ -16,15 +17,16 @@ apiRouter.get('/', (req: Request, res: Response, next: NextFunction) => {
 });
 
 // This middleware was used for testing
-const will = (req: Request, res: Response, next: NextFunction) => {
-  res.locals.id = 'test';
-  return next();
-};
+// const will = (req: Request, res: Response, next: NextFunction) => {
+//   res.locals.id = 'test';
+//   return next();
+// };
 
 // Create
 apiRouter.post(
   '/captures',
-  will /* will's middlware, */,
+  // will /* will's middlware, */,
+  fileController.addData,
   flamegraph.stackCollapse,
   flamegraph.toSVG,
   (req: Request, res: Response) => res


### PR DESCRIPTION
Replace temp working file.controller in api.router.ts to use real file.controller. Reinstate a placeholder id on res.locals.id. Ensure upon file upload on the front-end, file.controller saves the file to db/uploads, renames the file using res.locals.id, moves file into db/captures as (res.locals.id).perf. This id is passed to flamegraphcontroller middleware functions stackCollapse and toSVG, which builds an SVG file of the name (res.locals.id) to db/SVGs.