### PR TITLE
Add state management to frontend

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
     "commist",
     "Flamegraph",
     "flamegraphs",
-    "Peasy"
+    "reduxjs"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
   "cSpell.words": [
     "commist",
-    "Flamegraph"
+    "Flamegraph",
+    "flamegraphs",
+    "Peasy"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "body-parser": "^1.20.0",
         "bootstrap": "^5.2.0",
         "dotenv": "^16.0.1",
+        "easy-peasy": "^5.0.4",
         "express": "^4.18.1",
         "formidable": "^2.0.1",
         "fs-extra": "^10.1.0",
@@ -6087,6 +6088,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/easy-peasy": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/easy-peasy/-/easy-peasy-5.0.4.tgz",
+      "integrity": "sha512-w4VmPGlUTkXWPmuDLRsdEdagEIGgKYJcnWoasb6NPpizFWrR2smojBLWys7kPrbdd4LIDhLtU2tXh8BIgP4rXw==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "immer": "^9.0.6",
+        "redux": "^4.1.1",
+        "redux-thunk": "^2.3.0",
+        "ts-toolbelt": "^9.6.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -8198,6 +8214,15 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "node_modules/immer": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/immutable": {
       "version": "4.1.0",
@@ -12110,6 +12135,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -13661,6 +13702,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -19176,6 +19222,18 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
+    "easy-peasy": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/easy-peasy/-/easy-peasy-5.0.4.tgz",
+      "integrity": "sha512-w4VmPGlUTkXWPmuDLRsdEdagEIGgKYJcnWoasb6NPpizFWrR2smojBLWys7kPrbdd4LIDhLtU2tXh8BIgP4rXw==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "immer": "^9.0.6",
+        "redux": "^4.1.1",
+        "redux-thunk": "^2.3.0",
+        "ts-toolbelt": "^9.6.0"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -20750,6 +20808,11 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "immer": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
     },
     "immutable": {
       "version": "4.1.0",
@@ -23656,6 +23719,20 @@
         "resolve": "^1.9.0"
       }
     },
+    "redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -24781,6 +24858,11 @@
         "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       }
+    },
+    "ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
     },
     "tsconfig-paths": {
       "version": "3.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,17 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.8.5",
         "body-parser": "^1.20.0",
         "bootstrap": "^5.2.0",
         "dotenv": "^16.0.1",
-        "easy-peasy": "^5.0.4",
         "express": "^4.18.1",
         "formidable": "^2.0.1",
         "fs-extra": "^10.1.0",
         "react": "^18.2.0",
         "react-bootstrap": "^2.5.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^8.0.2",
         "react-router-bootstrap": "^0.26.2",
         "react-router-dom": "^6.3.0",
         "sqlite3": "^5.0.11"
@@ -36,6 +37,7 @@
         "@types/node": "^18.7.2",
         "@types/react": "^18.0.17",
         "@types/react-dom": "^18.0.6",
+        "@types/react-redux": "^7.1.24",
         "@types/react-router": "^5.1.18",
         "@types/react-router-bootstrap": "^0.24.5",
         "@types/react-router-dom": "^5.3.3",
@@ -3174,6 +3176,29 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.5.tgz",
+      "integrity": "sha512-f4D5EXO7A7Xq35T0zRbWq5kJQyXzzscnHKmjnu2+37B3rwHU6mX9PYlbfXdnxcY6P/7zfmjhgan0Z+yuOfeBmA==",
+      "dependencies": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@restart/hooks": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.7.tgz",
@@ -3429,6 +3454,15 @@
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
       "dev": true
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -3545,9 +3579,21 @@
       "version": "18.0.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
       "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.24",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
+      "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/react-router": {
@@ -3661,6 +3707,11 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -6088,21 +6139,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/easy-peasy": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/easy-peasy/-/easy-peasy-5.0.4.tgz",
-      "integrity": "sha512-w4VmPGlUTkXWPmuDLRsdEdagEIGgKYJcnWoasb6NPpizFWrR2smojBLWys7kPrbdd4LIDhLtU2tXh8BIgP4rXw==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "immer": "^9.0.6",
-        "redux": "^4.1.1",
-        "redux-thunk": "^2.3.0",
-        "ts-toolbelt": "^9.6.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -7891,6 +7927,19 @@
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -12039,13 +12088,50 @@
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-redux": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-router": {
       "version": "6.3.0",
@@ -12301,6 +12387,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
+    },
+    "node_modules/reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -13703,11 +13794,6 @@
         }
       }
     },
-    "node_modules/ts-toolbelt": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -13990,6 +14076,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -16912,6 +17006,17 @@
         "@babel/runtime": "^7.6.2"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.5.tgz",
+      "integrity": "sha512-f4D5EXO7A7Xq35T0zRbWq5kJQyXzzscnHKmjnu2+37B3rwHU6mX9PYlbfXdnxcY6P/7zfmjhgan0Z+yuOfeBmA==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
+    },
     "@restart/hooks": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.7.tgz",
@@ -17157,6 +17262,15 @@
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
       "dev": true
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -17273,9 +17387,21 @@
       "version": "18.0.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
       "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.24",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
+      "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
+      "dev": true,
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/react-router": {
@@ -17389,6 +17515,11 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/warning": {
       "version": "3.0.0",
@@ -19222,18 +19353,6 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
-    "easy-peasy": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/easy-peasy/-/easy-peasy-5.0.4.tgz",
-      "integrity": "sha512-w4VmPGlUTkXWPmuDLRsdEdagEIGgKYJcnWoasb6NPpizFWrR2smojBLWys7kPrbdd4LIDhLtU2tXh8BIgP4rXw==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "immer": "^9.0.6",
-        "redux": "^4.1.1",
-        "redux-thunk": "^2.3.0",
-        "ts-toolbelt": "^9.6.0"
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -20555,6 +20674,21 @@
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
       "requires": {
         "@babel/runtime": "^7.7.6"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "hpack.js": {
@@ -23647,13 +23781,25 @@
     "react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-redux": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      }
     },
     "react-router": {
       "version": "6.3.0",
@@ -23852,6 +23998,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
+    },
+    "reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "resolve": {
       "version": "1.22.1",
@@ -24859,11 +25010,6 @@
         "yn": "3.1.1"
       }
     },
-    "ts-toolbelt": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
-    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -25068,6 +25214,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/node": "^18.7.2",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
+    "@types/react-redux": "^7.1.24",
     "@types/react-router": "^5.1.18",
     "@types/react-router-bootstrap": "^0.24.5",
     "@types/react-router-dom": "^5.3.3",
@@ -110,16 +111,17 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.8.5",
     "body-parser": "^1.20.0",
     "bootstrap": "^5.2.0",
     "dotenv": "^16.0.1",
-    "easy-peasy": "^5.0.4",
     "express": "^4.18.1",
     "formidable": "^2.0.1",
     "fs-extra": "^10.1.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.5.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^8.0.2",
     "react-router-bootstrap": "^0.26.2",
     "react-router-dom": "^6.3.0",
     "sqlite3": "^5.0.11"

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "body-parser": "^1.20.0",
     "bootstrap": "^5.2.0",
     "dotenv": "^16.0.1",
+    "easy-peasy": "^5.0.4",
     "express": "^4.18.1",
     "formidable": "^2.0.1",
     "fs-extra": "^10.1.0",

--- a/src/public/infernode/components/layout/NavBar/Login.tsx
+++ b/src/public/infernode/components/layout/NavBar/Login.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import { useAppSelector, useAppDispatch } from '../../../store/hooks';
+import {
+  login,
+  logout,
+  updatePassword,
+  updateUsername,
+  togglePopover,
+} from '../../../store/userSlice';
+
+export function LoginButton(): JSX.Element {
+  const { popover } = useAppSelector((state) => state.user);
+  const dispatch = useAppDispatch();
+
+  return (
+    <OverlayTrigger
+      key="login"
+      placement="bottom"
+      show={popover}
+      overlay={(
+        <Popover id="login-popover">
+          <Popover.Header> INFERNOde Account</Popover.Header>
+          <Popover.Body>
+            <Form>
+              <Form.Control
+                type="text"
+                id="inputUsername"
+                onChange={(e) => dispatch(updateUsername(`${e.target.value}`))}
+                placeholder="username"
+              />
+              <Form.Control
+                type="password"
+                id="inputPassword"
+                placeholder="password"
+                onChange={(e) => dispatch(updatePassword(`${e.target.value}`))}
+              />
+              <Button onClick={() => dispatch(login())}>Submit</Button>
+            </Form>
+          </Popover.Body>
+        </Popover>
+        )}
+    >
+      <Button onClick={() => dispatch(togglePopover())} className="mx-2">Login</Button>
+    </OverlayTrigger>
+  );
+}
+
+export function LogoutButton(): JSX.Element {
+  const { popover, username } = useAppSelector((state) => state.user);
+  const dispatch = useAppDispatch();
+
+  return (
+    <OverlayTrigger
+      key="logout"
+      placement="bottom"
+      show={popover}
+      overlay={(
+        <Popover id="login-popover">
+          <Popover.Header> INFERNOde Account</Popover.Header>
+          <Popover.Body>
+            {username && `Logged in as: ${username}`}
+            <Button onClick={() => dispatch(logout())}>Logout</Button>
+          </Popover.Body>
+        </Popover>
+      )}
+    >
+      <Button variant="secondary" onClick={() => dispatch(togglePopover())} className="mx-2">{username}</Button>
+    </OverlayTrigger>
+  );
+}

--- a/src/public/infernode/components/layout/NavBar/NavBar.tsx
+++ b/src/public/infernode/components/layout/NavBar/NavBar.tsx
@@ -5,11 +5,14 @@ import ToggleButton from 'react-bootstrap/ToggleButton';
 import Navbar from 'react-bootstrap/Navbar';
 import Nav from 'react-bootstrap/Nav';
 import { LinkContainer } from 'react-router-bootstrap';
-import { useStoreState, useStoreActions } from '../../../store/store';
+import { useAppSelector, useAppDispatch } from '../../../store/hooks';
+import { toggleDarkMode } from '../../../store/configSlice';
+import { LoginButton, LogoutButton } from './Login';
 
 export default function NavBar(): JSX.Element {
-  const isDarkMode = useStoreState((state) => state.config.darkMode);
-  const toggleDarkMode = useStoreActions((actions) => actions.config.toggleDarkMode);
+  const isDarkMode = useAppSelector((state) => state.config.darkMode);
+  const { authenticated } = useAppSelector((state) => state.user);
+  const dispatch = useAppDispatch();
 
   let bg = 'light';
   let variant = 'light';
@@ -19,7 +22,7 @@ export default function NavBar(): JSX.Element {
   }
 
   return (
-    <Navbar bg={bg} variant={variant} className="mb-2">
+    <Navbar expand="md" sticky="top" bg={bg} variant={variant} className="mb-2">
       <Container>
         <Navbar.Brand href="#home">
           <img
@@ -47,18 +50,18 @@ export default function NavBar(): JSX.Element {
               <Nav.Link>Help</Nav.Link>
             </LinkContainer>
           </Nav>
-          <ButtonGroup className="mb-2">
+          <ButtonGroup className="mx-2">
             <ToggleButton
               id="toggle-check"
               type="checkbox"
               variant="secondary"
               checked={isDarkMode}
               value="1"
-              onChange={() => toggleDarkMode(isDarkMode)}
+              onChange={() => dispatch(toggleDarkMode())}
             >
               {(isDarkMode && '🌔') || '🌒'}
-              {`${isDarkMode}`}
             </ToggleButton>
+            {(authenticated && <LogoutButton />) || <LoginButton />}
           </ButtonGroup>
         </Navbar.Collapse>
       </Container>

--- a/src/public/infernode/components/layout/NavBar/NavBar.tsx
+++ b/src/public/infernode/components/layout/NavBar/NavBar.tsx
@@ -1,13 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Container from 'react-bootstrap/Container';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import ToggleButton from 'react-bootstrap/ToggleButton';
 import Navbar from 'react-bootstrap/Navbar';
 import Nav from 'react-bootstrap/Nav';
 import { LinkContainer } from 'react-router-bootstrap';
+import { useStoreState, useStoreActions } from '../../../store/store';
 
 export default function NavBar(): JSX.Element {
-  const [isDarkMode, setDarkMode] = useState(false);
+  const isDarkMode = useStoreState((state) => state.config.darkMode);
+  const toggleDarkMode = useStoreActions((actions) => actions.config.toggleDarkMode);
 
   let bg = 'light';
   let variant = 'light';
@@ -52,9 +54,10 @@ export default function NavBar(): JSX.Element {
               variant="secondary"
               checked={isDarkMode}
               value="1"
-              onChange={() => setDarkMode(!isDarkMode)}
+              onChange={() => toggleDarkMode(isDarkMode)}
             >
               {(isDarkMode && '🌔') || '🌒'}
+              {`${isDarkMode}`}
             </ToggleButton>
           </ButtonGroup>
         </Navbar.Collapse>

--- a/src/public/infernode/index.tsx
+++ b/src/public/infernode/index.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { StoreProvider } from 'easy-peasy';
 import App from './App';
+import store from './store/store';
+
+//! Temporary fix for React 18 compatibility issues in Easy-Peasy
+//* See: https://github.com/ctrlplusb/easy-peasy/issues/741
+//*      https://github.com/ctrlplusb/easy-peasy/pull/745
+
+type Props = StoreProvider['props'] & { children: React.ReactNode };
+const StoreProviderCasted = StoreProvider as unknown as React.ComponentType<Props>;
 
 const rootEle = document.getElementById('root');
-if (rootEle === null) throw new Error('Failed to find root element for React app');
+if (rootEle === null) {
+  throw new Error('Failed to find root element for React app');
+}
 const root = createRoot(rootEle);
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <StoreProviderCasted store={store}>
+        <App />
+      </StoreProviderCasted>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/src/public/infernode/index.tsx
+++ b/src/public/infernode/index.tsx
@@ -1,16 +1,9 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import { StoreProvider } from 'easy-peasy';
+import { Provider } from 'react-redux';
 import App from './App';
-import store from './store/store';
-
-//! Temporary fix for React 18 compatibility issues in Easy-Peasy
-//* See: https://github.com/ctrlplusb/easy-peasy/issues/741
-//*      https://github.com/ctrlplusb/easy-peasy/pull/745
-
-type Props = StoreProvider['props'] & { children: React.ReactNode };
-const StoreProviderCasted = StoreProvider as unknown as React.ComponentType<Props>;
+import { store } from './store/store';
 
 const rootEle = document.getElementById('root');
 if (rootEle === null) {
@@ -20,9 +13,9 @@ const root = createRoot(rootEle);
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <StoreProviderCasted store={store}>
+      <Provider store={store}>
         <App />
-      </StoreProviderCasted>
+      </Provider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/src/public/infernode/store/captureSlice.ts
+++ b/src/public/infernode/store/captureSlice.ts
@@ -1,0 +1,44 @@
+/* eslint no-param-reassign: 0 */
+//* redux-toolkit uses immer to wrap state changes, so param reassignment is not only
+//* acceptable, but is the typical pattern for writing actions.
+
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+export interface Capture {
+  id: number;
+  captureName: string;
+  date: Date;
+  creator: string;
+  appName: string;
+  data: string;
+  saved: boolean;
+}
+
+export interface CaptureState {
+  captureList: Capture[];
+  current: number | null;
+  loading: boolean;
+}
+
+const initialState: CaptureState = {
+  captureList: [],
+  current: null,
+  loading: false,
+};
+
+export const captureSlice = createSlice({
+  name: 'captures',
+  initialState,
+  reducers: {
+    addCapture: (state, action: PayloadAction<Capture>) => {
+      state.captureList.push(action.payload);
+    },
+    deleteCapture: (state, action: PayloadAction<number>) => {
+      state.captureList = state.captureList.filter((capture) => capture.id !== action.payload);
+    },
+  },
+});
+
+export const { addCapture, deleteCapture } = captureSlice.actions;
+export default captureSlice.reducer;

--- a/src/public/infernode/store/configSlice.ts
+++ b/src/public/infernode/store/configSlice.ts
@@ -1,0 +1,30 @@
+/* eslint no-param-reassign: 0 */
+//* redux-toolkit uses immer to wrap state changes, so param reassignment is not only
+//* acceptable, but is the typical pattern for writing actions.
+
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+export interface ConfigState {
+  darkMode: boolean,
+}
+
+const initialState: ConfigState = {
+  darkMode: true,
+};
+
+export const configSlice = createSlice({
+  name: 'config',
+  initialState,
+  reducers: {
+    setDarkMode: (state, action: PayloadAction<boolean>) => {
+      state.darkMode = action.payload;
+    },
+    toggleDarkMode: (state) => {
+      state.darkMode = !state.darkMode;
+    },
+  },
+});
+
+export const { setDarkMode, toggleDarkMode } = configSlice.actions;
+export default configSlice.reducer;

--- a/src/public/infernode/store/hooks.ts
+++ b/src/public/infernode/store/hooks.ts
@@ -1,0 +1,6 @@
+import { useDispatch, useSelector } from 'react-redux';
+import type { TypedUseSelectorHook } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/public/infernode/store/store.ts
+++ b/src/public/infernode/store/store.ts
@@ -1,0 +1,75 @@
+/* eslint no-param-reassign: 0 */
+//* easy-peasy uses immer to wrap state changes, so param reassignment is not only
+//* acceptable, but is the typical pattern for writing actions.
+
+import {
+  createStore, createTypedHooks, Action, action, Thunk, thunk,
+} from 'easy-peasy';
+
+interface Capture {
+  id: number;
+  captureName: string;
+  date: Date;
+  creator: string;
+  appName: string;
+  data: string;
+  saved: boolean,
+}
+
+interface CapturesModel {
+  captureList: Capture[];
+  addCapture: Action<CapturesModel, Capture>;
+  // deleteCapture: Action<CapturesModel, Capture>;
+  // syncCaptures: Thunk<CapturesModel, Capture>;
+}
+
+interface UserModel {
+  id: number | null;
+  username: string | null;
+  authenticated: boolean;
+}
+
+interface ConfigModel {
+  darkMode: boolean;
+  setDarkMode: Action<ConfigModel, boolean>;
+  toggleDarkMode: Action<ConfigModel, boolean>;
+}
+
+interface StoreModel {
+  captures: CapturesModel;
+  user: UserModel;
+  config: ConfigModel;
+}
+
+const store = createStore<StoreModel>({
+  captures: {
+    captureList: [],
+    addCapture: action((state, payload: Capture) => {
+      state.captureList.push(payload);
+    }),
+  },
+
+  user: {
+    id: null,
+    username: null,
+    authenticated: false,
+  },
+
+  config: {
+    darkMode: true,
+    setDarkMode: action((state, payload: boolean) => {
+      state.darkMode = payload;
+    }),
+    toggleDarkMode: action((state) => {
+      state.darkMode = !state.darkMode;
+    }),
+  },
+
+});
+
+const typedHooks = createTypedHooks<StoreModel>();
+
+export const { useStoreActions } = typedHooks;
+export const { useStoreDispatch } = typedHooks;
+export const { useStoreState } = typedHooks;
+export default store;

--- a/src/public/infernode/store/store.ts
+++ b/src/public/infernode/store/store.ts
@@ -1,75 +1,15 @@
-/* eslint no-param-reassign: 0 */
-//* easy-peasy uses immer to wrap state changes, so param reassignment is not only
-//* acceptable, but is the typical pattern for writing actions.
+import { configureStore } from '@reduxjs/toolkit';
+import configReducer from './configSlice';
+import captureReducer from './captureSlice';
+import userReducer from './userSlice';
 
-import {
-  createStore, createTypedHooks, Action, action, Thunk, thunk,
-} from 'easy-peasy';
-
-interface Capture {
-  id: number;
-  captureName: string;
-  date: Date;
-  creator: string;
-  appName: string;
-  data: string;
-  saved: boolean,
-}
-
-interface CapturesModel {
-  captureList: Capture[];
-  addCapture: Action<CapturesModel, Capture>;
-  // deleteCapture: Action<CapturesModel, Capture>;
-  // syncCaptures: Thunk<CapturesModel, Capture>;
-}
-
-interface UserModel {
-  id: number | null;
-  username: string | null;
-  authenticated: boolean;
-}
-
-interface ConfigModel {
-  darkMode: boolean;
-  setDarkMode: Action<ConfigModel, boolean>;
-  toggleDarkMode: Action<ConfigModel, boolean>;
-}
-
-interface StoreModel {
-  captures: CapturesModel;
-  user: UserModel;
-  config: ConfigModel;
-}
-
-const store = createStore<StoreModel>({
-  captures: {
-    captureList: [],
-    addCapture: action((state, payload: Capture) => {
-      state.captureList.push(payload);
-    }),
+export const store = configureStore({
+  reducer: {
+    config: configReducer,
+    captures: captureReducer,
+    user: userReducer,
   },
-
-  user: {
-    id: null,
-    username: null,
-    authenticated: false,
-  },
-
-  config: {
-    darkMode: true,
-    setDarkMode: action((state, payload: boolean) => {
-      state.darkMode = payload;
-    }),
-    toggleDarkMode: action((state) => {
-      state.darkMode = !state.darkMode;
-    }),
-  },
-
 });
 
-const typedHooks = createTypedHooks<StoreModel>();
-
-export const { useStoreActions } = typedHooks;
-export const { useStoreDispatch } = typedHooks;
-export const { useStoreState } = typedHooks;
-export default store;
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/public/infernode/store/userSlice.ts
+++ b/src/public/infernode/store/userSlice.ts
@@ -1,0 +1,69 @@
+/* eslint no-param-reassign: 0 */
+//* redux-toolkit uses immer to wrap state changes, so param reassignment is not only
+//* acceptable, but is the typical pattern for writing actions.
+
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+export interface UserState {
+  id: number | null;
+  username: string | null;
+  authenticated: boolean;
+  submit: {
+    username: string,
+    password: string,
+  },
+  popover: boolean,
+}
+
+export interface UserLogin {
+  username: string;
+  password: string;
+}
+
+const initialState: UserState = {
+  id: null,
+  username: null,
+  authenticated: false,
+  submit: {
+    username: '',
+    password: '',
+  },
+  popover: false,
+};
+
+export const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {
+    // todo: placeholder only, does not do any authentication checks
+    login: (state) => {
+      state.username = state.submit.username;
+      state.authenticated = true;
+      state.id = 0;
+      state.popover = false;
+      state.submit.username = '';
+      state.submit.password = '';
+    },
+    logout: (state) => {
+      state.popover = false;
+      state.username = null;
+      state.authenticated = false;
+      state.id = null;
+    },
+    updateUsername: (state, action: PayloadAction<string>) => {
+      state.submit.username = action.payload;
+    },
+    updatePassword: (state, action: PayloadAction<string>) => {
+      state.submit.password = action.payload;
+    },
+    togglePopover: (state) => {
+      state.popover = !state.popover;
+    },
+  },
+});
+
+export const {
+  login, logout, updatePassword, updateUsername, togglePopover,
+} = userSlice.actions;
+export default userSlice.reducer;


### PR DESCRIPTION
Add redux via redux-toolkit.
Implement initial state and actions for captures, current user, and dark mode.
Implement basic login/logout ui elements to demonstrate state usage.

Does not include any connectivity of state to backend.

Closes #13, close #15.