### PR TITLE
Add fetchAllCaptures reducer and wiring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "commist",
     "Flamegraph",
     "flamegraphs",
+    "immer",
     "infernode",
     "reduxjs"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.5",
+        "axios": "^0.27.2",
         "body-parser": "^1.20.0",
         "bootstrap": "^5.2.0",
         "dotenv": "^16.0.1",
@@ -4686,8 +4687,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axe-core": {
       "version": "4.4.3",
@@ -4696,6 +4696,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/axobject-query": {
@@ -5413,7 +5422,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5915,7 +5923,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7357,7 +7364,6 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
       "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7511,7 +7517,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -18234,14 +18239,22 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axe-core": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -18796,7 +18809,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -19181,8 +19193,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -20276,8 +20287,7 @@
     "follow-redirects": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
-      "dev": true
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "fork-ts-checker-notifier-webpack-plugin": {
       "version": "6.0.0",
@@ -20372,7 +20382,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.5",
+    "axios": "^0.27.2",
     "body-parser": "^1.20.0",
     "bootstrap": "^5.2.0",
     "dotenv": "^16.0.1",

--- a/src/controllers/file.controller.ts
+++ b/src/controllers/file.controller.ts
@@ -12,7 +12,6 @@ export default class FileController {
 
   addData = (req: Request, res: Response, next: NextFunction) => {
     // Get next ID
-    res.locals.id = 12345;
     const fileId = Number(res.locals.id);
     // console.log('LOOK OVER HERE!', fileId);
     // const fileId = 123;

--- a/src/public/infernode/App.tsx
+++ b/src/public/infernode/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Container } from 'react-bootstrap';
 import './App.scss';
 import { Routes, Route } from 'react-router-dom';
@@ -8,8 +8,19 @@ import HelpPage from './views/Help/HelpPage';
 import * as HelpPages from './views/Help/HelpPages';
 import HistoryPage from './views/History/HistoryPage';
 import ManagePage from './views/Manage/ManagePage';
+import { useAppDispatch } from './store/hooks';
+import { fetchAllCaptures } from './store/captureSlice';
 
 export default function App(): JSX.Element {
+  const dispatch = useAppDispatch();
+
+  // Get capture list once on app mount
+  useEffect(() => {
+    async function blah(): Promise<void> { await dispatch(fetchAllCaptures()); }
+    // eslint-disable-next-line no-console
+    blah().catch((err) => console.log('Error: failed to fetch data on App mount: ', err));
+  }, [dispatch]);
+
   return (
     <>
       <NavBar />

--- a/src/public/infernode/services/Api.ts
+++ b/src/public/infernode/services/Api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export default () => axios.create({
+  baseURL: '/api/',
+  headers: {
+    Accept: 'application/json',
+  },
+});

--- a/src/public/infernode/services/captureService.ts
+++ b/src/public/infernode/services/captureService.ts
@@ -1,0 +1,22 @@
+/* eslint-disable no-console */
+import axios from 'axios';
+import Api from './Api';
+import { Capture } from '../store/interfaces';
+
+export default {
+  async getAll() {
+    try {
+      const { data, status } = await Api().get<Capture[]>('captures');
+      if (status === 200) return data;
+      console.log(`Error: unexpected HTTP response code: ${status}`);
+      return [];
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        console.log(`Error: axios: ${JSON.stringify(err)}`);
+        return [];
+      }
+      console.log(`Error: unknown: ${JSON.stringify(err)}`);
+      return [];
+    }
+  },
+};

--- a/src/public/infernode/store/captureSlice.ts
+++ b/src/public/infernode/store/captureSlice.ts
@@ -1,19 +1,12 @@
+/* eslint-disable no-console */
 /* eslint no-param-reassign: 0 */
 //* redux-toolkit uses immer to wrap state changes, so param reassignment is not only
 //* acceptable, but is the typical pattern for writing actions.
 
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
-
-export interface Capture {
-  id: number;
-  captureName: string;
-  date: Date;
-  creator: string;
-  appName: string;
-  data: string;
-  saved: boolean;
-}
+import { Capture } from './interfaces';
+import captures from '../services/captureService';
 
 export interface CaptureState {
   captureList: Capture[];
@@ -27,6 +20,14 @@ const initialState: CaptureState = {
   loading: false,
 };
 
+export const fetchAllCaptures = createAsyncThunk<Capture[]>(
+  'captures/fetchAll',
+  async () => {
+    const result = await captures.getAll();
+    return result;
+  },
+);
+
 export const captureSlice = createSlice({
   name: 'captures',
   initialState,
@@ -35,8 +36,24 @@ export const captureSlice = createSlice({
       state.captureList.push(action.payload);
     },
     deleteCapture: (state, action: PayloadAction<number>) => {
-      state.captureList = state.captureList.filter((capture) => capture.id !== action.payload);
+      state.captureList = state.captureList.filter(
+        (capture) => capture.id !== action.payload,
+      );
     },
+    setCaptures: (state, action: PayloadAction<Capture[]>) => {
+      state.captureList = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchAllCaptures.fulfilled, (state, action) => {
+      console.log('fulfilled', JSON.stringify(action));
+      state.captureList = action.payload;
+    });
+    builder.addCase(fetchAllCaptures.rejected, (state, action) => {
+      console.log('REJECTED', JSON.stringify(action));
+      console.log('fetchAllCaptures resolved to error: ', action.payload || action.error);
+      state.captureList = [];
+    });
   },
 });
 

--- a/src/public/infernode/store/interfaces.ts
+++ b/src/public/infernode/store/interfaces.ts
@@ -5,5 +5,4 @@ export interface Capture {
   creator: string;
   appName: string;
   data: string;
-  saved: boolean;
 }

--- a/src/public/infernode/store/interfaces.ts
+++ b/src/public/infernode/store/interfaces.ts
@@ -1,0 +1,9 @@
+export interface Capture {
+  id: number;
+  captureName: string;
+  date: Date;
+  creator: string;
+  appName: string;
+  data: string;
+  saved: boolean;
+}

--- a/src/routes/api.router.ts
+++ b/src/routes/api.router.ts
@@ -8,17 +8,27 @@ import { dbControllerInstance } from '../controllers/db.controller';
 
 const apiRouter = Router();
 
+// API Root
 apiRouter.get('/', (req: Request, res: Response, next: NextFunction) => {
   console.log(
-    `${new Date().toLocaleString()}: apiRouter handling ${req.method} ${
+    `${new Date().toLocaleString()}: API Root apiRouter handling ${req.method} ${
       req.url
     }`,
   );
   return next({ message: 'GET /api/ not yet implemented' });
 });
 
+// Create
 apiRouter.post(
   '/captures',
+  (req: Request, res: Response, next: NextFunction) => {
+    console.log(
+      `${new Date().toLocaleString()}: Create apiRouter handling ${req.method} ${
+        req.url
+      }`,
+    );
+    next();
+  },
   dbControllerInstance.createEmptyRecord,
   fileController.addData,
   flamegraph.stackCollapse,
@@ -30,12 +40,12 @@ apiRouter.post(
   // architecture and how we want the user to see what they just uploaded
 );
 
-// Create/Update by ID
+// Create by ID
 apiRouter.put(
   '/captures/:id',
   (req: Request, res: Response, next: NextFunction) => {
     console.log(
-      `${new Date().toLocaleString()}: apiRouter handling ${req.method} ${
+      `${new Date().toLocaleString()}: Create by ID apiRouter handling ${req.method} ${
         req.url
       }`,
     );
@@ -46,15 +56,28 @@ apiRouter.put(
 // Read All
 apiRouter.get(
   '/captures', /* dbController.getAllMetaData */
-  (req: Request, res: Response) => res.status(200).json('Fetch meta data sucessfully'),
+  (req: Request, res: Response) => res.status(200).json([
+    {
+      id: 1, captureName: 'capture 1', date: Date.now(), creator: 'test 1', appName: 'app 1', data: '',
+    },
+    {
+      id: 2, captureName: 'capture 2', date: Date.now(), creator: 'test 2', appName: 'app 2', data: '',
+    },
+    {
+      id: 3, captureName: 'capture 3', date: Date.now(), creator: 'test 3', appName: 'app 3', data: '',
+    },
+    {
+      id: 4, captureName: 'capture 4', date: Date.now(), creator: 'test 4', appName: 'app 4', data: '',
+    },
+  ]),
 );
 
-// Read
+// Read by ID
 apiRouter.get(
   '/captures/:id', // req.param
   (req: Request, res: Response, next: NextFunction) => {
     console.log(
-      `${new Date().toLocaleString()}: WANT TO SEE THIS apiRouter handling ${req.method} ${
+      `${new Date().toLocaleString()}: Read by ID apiRouter handling ${req.method} ${
         req.url
       }`,
     );
@@ -63,12 +86,12 @@ apiRouter.get(
   fileController.deliverSVG,
 );
 
-// Update
+// Update by ID
 apiRouter.patch(
   '/captures/:id',
   (req: Request, res: Response, next: NextFunction) => {
     console.log(
-      `${new Date().toLocaleString()}: apiRouter handling ${req.method} ${
+      `${new Date().toLocaleString()}: Update by ID apiRouter handling ${req.method} ${
         req.url
       }`,
     );
@@ -76,19 +99,17 @@ apiRouter.patch(
   },
 );
 
-// Delete
+// Delete by ID
 apiRouter.delete(
   '/captures/:id',
   (req: Request, res: Response, next: NextFunction) => {
     console.log(
-      `${new Date().toLocaleString()}: apiRouter handling ${req.method} ${
+      `${new Date().toLocaleString()}: Delete by ID apiRouter handling ${req.method} ${
         req.url
       }`,
     );
     next({ message: 'DELETE /api/captures/:id not yet implemented' });
   },
 );
-
-// define a global err handler based on the server.globalError method
 
 export default apiRouter;

--- a/src/routes/api.router.ts
+++ b/src/routes/api.router.ts
@@ -4,7 +4,7 @@ import {
 } from 'express';
 import flamegraph from '../controllers/flamegraphController';
 import { fileController } from '../controllers/controllers.module';
-import { dbControllerInstance } from '../controllers/db.controller';
+import { dbControllerInstance, getAllRows } from '../controllers/db.controller';
 
 const apiRouter = Router();
 
@@ -56,20 +56,8 @@ apiRouter.put(
 // Read All
 apiRouter.get(
   '/captures', /* dbController.getAllMetaData */
-  (req: Request, res: Response) => res.status(200).json([
-    {
-      id: 1, captureName: 'capture 1', date: Date.now(), creator: 'test 1', appName: 'app 1', data: '',
-    },
-    {
-      id: 2, captureName: 'capture 2', date: Date.now(), creator: 'test 2', appName: 'app 2', data: '',
-    },
-    {
-      id: 3, captureName: 'capture 3', date: Date.now(), creator: 'test 3', appName: 'app 3', data: '',
-    },
-    {
-      id: 4, captureName: 'capture 4', date: Date.now(), creator: 'test 4', appName: 'app 4', data: '',
-    },
-  ]),
+  getAllRows,
+  (req: Request, res: Response) => res.status(200).json(res.locals.rows),
 );
 
 // Read by ID


### PR DESCRIPTION
Adds an async (thunk) reducer that fetches all capture records from the backend API and stores them in the captures state.
Triggers an initial fetchAllCaptures call on initial app mount.
Wires up DB controller to get all route.
Configures file controller to use DB controller derived id.

Related to #54 