### PR TITLE
Refactor/nodekill

### DIFF
--- a/src/controllers/application.controller.ts
+++ b/src/controllers/application.controller.ts
@@ -5,7 +5,6 @@ import { spawn, execSync } from 'child_process';
 import { existsSync } from 'fs-extra';
 import { InfernodeError } from '../utils/globalErrorHandler';
 import logger from '../utils/logging';
-import { resourceLimits } from 'worker_threads';
 
 type ProcessInfo = {
   userId: number | null; // Can remove null as an option when auth is implemented

--- a/src/controllers/application.controller.ts
+++ b/src/controllers/application.controller.ts
@@ -5,6 +5,7 @@ import { spawn, execSync } from 'child_process';
 import { existsSync } from 'fs-extra';
 import { InfernodeError } from '../utils/globalErrorHandler';
 import logger from '../utils/logging';
+import { resourceLimits } from 'worker_threads';
 
 type ProcessInfo = {
   userId: number | null; // Can remove null as an option when auth is implemented
@@ -15,7 +16,7 @@ type ReqBody = {
 };
 
 type BodyWithPid = {
-  pid: number;
+  pid?: number;
 };
 
 // note reqBody and Reqbody are not the same thing
@@ -108,15 +109,23 @@ class ApplicationController {
 
   public nodeKill = (req: Request, res: Response, next: NextFunction) => {
     try {
-      const reqBody: BodyWithPid | object = req.body as BodyWithPid | object;
-      if (!('pid' in reqBody)) {
-        throw new Error('There was an issue with the request body given to nodeKill');
+      const reqBody = req.body as BodyWithPid;
+      const resLocals = res.locals as BodyWithPid;
+      if ('pid' in reqBody) {
+        if (typeof reqBody.pid !== 'number') {
+          throw new Error();
+        }
       }
-      const { pid } = reqBody;
+      let pid;
+      if ('pid' in reqBody || 'pid' in resLocals) {
+        pid = 'pid' in reqBody ? reqBody.pid : resLocals.pid;
+      } else {
+        throw new Error();
+      }
       // check if node process is currently running
       // if not, return an error
       if (typeof pid !== 'number') throw new TypeError('Incorrect type passed in to req.body');
-      if (reqBody.pid in this.runningProcesses) {
+      if (pid in this.runningProcesses) {
         const result = process.kill(pid);
         console.log('child process killed?', result, ' - pid: ', pid);
         return next();

--- a/src/routes/dtrace.router.ts
+++ b/src/routes/dtrace.router.ts
@@ -52,6 +52,7 @@ dtraceRouter.post(
   DtraceController.foldDtrace,
   perfController.foldPerf,
   flamegraphController.toSVG,
+  applicationController.nodeKill,
   (_req: Request, res: Response) => {
     res.status(200).send('test successful');
   },
@@ -68,6 +69,7 @@ dtraceRouter.post(
   DtraceController.foldDtrace,
   perfController.foldPerf,
   icicleController.toIcicleSVG,
+  applicationController.nodeKill,
   (_req: Request, res: Response) => {
     res.status(200).send('test successful');
   },


### PR DESCRIPTION
refactored dtrace routers to run NodeKill when the user starts the app and dtrace/perf at the same time. Nodekill will now run immediately after dtrace/perf ends.