### PR TITLE
fix(react index.tsx): change react-router to MemoryRouter to fix nav

### DIFF
--- a/src/public/infernode/index.tsx
+++ b/src/public/infernode/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import App from './App';
 import { store } from './store/store';
@@ -12,10 +12,10 @@ if (rootEle === null) {
 const root = createRoot(rootEle);
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
+    <MemoryRouter>
       <Provider store={store}>
         <App />
       </Provider>
-    </BrowserRouter>
+    </MemoryRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
Replaces BrowserRouter with MemoryRouter. This resolves the 404 on refresh problem that we encounter due to not using server side rendeirng. Instead, on refresh, a user will return to the app landing page.