### PR TITLE
fix(node.js.yml): Remove workflow-2 trigger from node.js GHA

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,11 +29,11 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
-    - name: Trigger next workflow
-      if: success()
-      uses: peter-evans/repository-dispatch@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        repository: oslabs-beta/infernode
-        event-type: trigger-workflow-2
-        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+#    - name: Trigger next workflow
+#      if: success()
+#      uses: peter-evans/repository-dispatch@v1
+#      with:
+#        token: ${{ secrets.GITHUB_TOKEN }}
+#        repository: oslabs-beta/infernode
+#        event-type: trigger-workflow-2
+#        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Looks like this fails if a PR author does not have actions to the GHA secrets. Probably need to move this to a separate workflow that only triggers when a team member does the merge to dev/main, rather than just on PR filing.